### PR TITLE
Add version number to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "engine",
+  "version": "0.1.0",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
It seems that npm can't install packages without a version number.
I just used 0.1.0 but that could of course be changed if you would like to use a different one.

This should fix #2 
