### PR TITLE
Fix _parsePgnGame() NAG symbol bug

### DIFF
--- a/src/board_variation.js
+++ b/src/board_variation.js
@@ -533,7 +533,11 @@ class BoardVariation {
         if (move) {
             this.eventLog.add(`makeMoveFromSan(${sanText}, ...) --> ${move.san}`);
 
-            return this.makeMove(move, game, metadata);
+            move.fenBefore = this.toFen();
+            const retVal = this.makeMove(move, game, metadata);
+            move.fenAfter = this.toFen();
+
+            return retVal;
         } else {
             this.eventLog.add(`makeMoveFromSan(${sanText}, ...) --> invalid move`);
 
@@ -556,7 +560,11 @@ class BoardVariation {
         if (move) {
             this.eventLog.add(`makeMoveFromAlgebraic(${from}, ${to}, ...) --> ${move.san}`);
 
-            return this.makeMove(move, game, metadata);
+            move.fenBefore = this.toFen();
+            const retVal = this.makeMove(move, game, metadata);
+            move.fenAfter = this.toFen();
+
+            return retVal;
         } else {
             this.eventLog.add(`makeMoveFromAlgebraic(${from}, ${to}, ...) --> invalid move`);
 

--- a/src/chess.js
+++ b/src/chess.js
@@ -224,6 +224,8 @@ class Chess {
                         // TODO this logic is broken;  there could be multiple comments;  need to push onto a .comments array;
                         // TODO figure out the interplay between metadata.comment and intraMoveAnnotationSlots;
                         // you should probably just have metadata link to the given slots?  instead of duplicating?
+                    } else {
+                        game.commentBeforeFirstMove = comment;
                     }
 
                     start = end;

--- a/src/chess.js
+++ b/src/chess.js
@@ -259,6 +259,22 @@ class Chess {
 
                     start = end - 1;
                     break;
+                    
+                case '!':
+                case '?':
+                    end = start;
+                    while('!?'.indexOf(ss.charAt(end)) >= 0) {
+                        end++;
+                    }
+
+                    let sanSuffix = ss.substring(start, end);
+
+                    if (prevMove) {
+                        prevMove.metadata.sanSuffix = sanSuffix;
+                    }
+
+                    start = end;
+                    break;    
 
                 default:
                     let sanText;

--- a/src/chess.js
+++ b/src/chess.js
@@ -245,7 +245,7 @@ class Chess {
                 case '$':
                     // http://en.wikipedia.org/wiki/Numeric_Annotation_Glyphs
                     end = start + 1;
-                    while(ss.charAt(end) != ' ') {
+                    while(ss.charAt(end).match(/[0-9]/)) {
                         end++;
                     }
 
@@ -257,7 +257,7 @@ class Chess {
                         game.currentVariation.intraMoveAnnotationSlots[game.currentVariation.selectedMoveHistoryIndex + 1] = [glyph];
                     }
 
-                    start = end;
+                    start = end - 1;
                     break;
 
                 default:


### PR DESCRIPTION
A NAG symbol immediately followed by a close variation token (i.e. with no intermediate whitespace) in PGN text no longer throws an error. For example

`21. Nxe4 Bf5 22. Nc3 $2 (22. a3 Be5 $13) 22... Qe7`

now parses correctly.